### PR TITLE
レイアウトの崩れの修正

### DIFF
--- a/app/assets/stylesheets/reviews/destroy.css.erb
+++ b/app/assets/stylesheets/reviews/destroy.css.erb
@@ -21,20 +21,11 @@
   border-radius: 10px;
 }
 
-.toppage-btn-wrapper {
-  width: 60%;
-  height: 48px;
-  margin: 15px auto;
-  text-decoration: none;
-}
-
 .toppage-btn {
-  background: #000000;
-  border: 1px solid #000000;
   color: #ffffff;
   line-height: 48px;
   font-size: 14px;
-  cursor: pointer;
   border-radius: 30px;
   padding: 15 100px;
+  margin-top: 10px;
 }

--- a/app/assets/stylesheets/reviews/search.css.erb
+++ b/app/assets/stylesheets/reviews/search.css.erb
@@ -7,8 +7,9 @@
 .result-content {
   background-color: #ffffff;
   width: 70%;
+  height: 100%;
   margin: 0 auto;
-  padding: 30px;
+  padding: 30px 0;
 }
 
 .result-title-wrapper {

--- a/app/views/reviews/destroy.html.erb
+++ b/app/views/reviews/destroy.html.erb
@@ -3,11 +3,9 @@
 <div class="delition-completed-wrapper">
   <div class="delition-completed">
     <h2>削除が完了しました</h2>
-    <%= link_to root_path, class:"toppage-btn-wrapper" do %>
       <div class="toppage-btn">
-        <p>トップページに戻る</p>
+        <%=link_to 'トップページにもどる', root_path, class: "back-button" %>
       </div>
-    <% end %>
   </div>
 </div>
 

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -10,8 +10,6 @@
     <ul class='review-lists'>
       <% if @results.length != 0 %>
         <% @results.each do |result| %>
-          <td>
-          <br>
           <li class='list'>
             <%= link_to review_path(result.id), class:"review-show-link" do %>
               <div class='review-info'>


### PR DESCRIPTION
# What
- 検索結果画面のレイアウトの崩れの修正
- 削除完了画面の「トップページに戻る」ボタンを他のページのものと同じように統一

# Why
- ユーザーにとって見やすい検索結果画面とするため。
- 同じ種類のボタンの見た目は、統一した方がユーザーにとってわかりやすいため。