### PR TITLE
いいねした投稿一覧表示画面の編集

### DIFF
--- a/app/assets/stylesheets/like/likes-page.css.erb
+++ b/app/assets/stylesheets/like/likes-page.css.erb
@@ -2,10 +2,10 @@
   padding: 50px 0;
   background-image: url("<%= asset_path("back-img.jpg") %>");
   background-size: cover;
-  height: calc(100vh - 130px) ;
   display: flex;
   justify-content: center;
   align-items: center;
+  min-height: 590px;
 }
 
 .likes-content {

--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -3,7 +3,7 @@
 <div class="likes-main">
   <div class="likes-content">
     <div class="likes-title-wrapper">
-      <h1 class="likes-title">いいねした投稿一覧</h1>
+      <h1 class="likes-title">いいねしたレビュー一覧</h1>
     </div>
     <ul class='review-lists'>
       <% if @likes.length == 0 %>


### PR DESCRIPTION
# What
- 「いいねした投稿一覧」を「いいねしたレビュー一覧」に変更した。
- 「min-height: 590px;」という記述に変更した。

# Why
- クラス名が「likes-main」のdiv要素に「height: calc(100vh - 130px) ;」を設定すると、いいねした投稿がある場合にレイアウトが大きく崩れてしまうため。