### PR TITLE
検索結果画面に検索フォームを設置

### DIFF
--- a/app/assets/stylesheets/reviews/search.css.erb
+++ b/app/assets/stylesheets/reviews/search.css.erb
@@ -4,21 +4,12 @@
   background-size: cover;
   display: flex;
   justify-content: center;
-  align-items: center;
   min-height: 590px;
-}
-
-.result-content {
-  background-color: #ffffff;
-  width: 70%;
-  height: 100%;
-  margin: 0 auto;
-  padding: 30px 0;
 }
 
 .result-title-wrapper {
   text-align: center;
-  margin-bottom: 30px;
+  margin: 30px;
 }
 
 .result-title {

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -10,97 +10,97 @@
     </div>
     <ul class='review-lists'>
       <% if @reviews.length > 0 %>
-          <% @reviews.each do |review| %>
-            <li class='list'>
-              <%= link_to review_path(review.id), class:"review-show-link" do %>
-                <div class='review-info'>
-                  <div class='review-img-content'>
-                    <%= image_tag review.image, class: "review-img" %>
+        <% @reviews.each do |review| %>
+          <li class='list'>
+            <%= link_to review_path(review.id), class:"review-show-link" do %>
+              <div class='review-info'>
+                <div class='review-img-content'>
+                  <%= image_tag review.image, class: "review-img" %>
+                </div>
+                <div class="top-review-detail">
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      商品名：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= review.name %>
+                    </h3>
                   </div>
-                  <div class="top-review-detail">
-                    <div class="top-review-group">
-                      <span class="top-review-name">
-                        商品名：
-                      </span>
-                      <h3 class="top-review-value">
-                        <%= review.name %>
-                      </h3>
-                    </div>
-                    <div class="top-review-group">
-                      <span class="top-review-name">
-                        ユーザー：
-                      </span>
-                      <h3 class="top-review-value">
-                        <%= review.user.nickname %>
-                      </h3>
-                    </div>
-                    <div class="top-review-group">
-                      <span class="top-review-name">
-                        メーカー：
-                      </span>
-                      <h3 class="top-review-value">
-                        <%= review.manufacture.name %>
-                      </h3>
-                    </div>
-                    <div class="top-review-group">
-                      <span class="top-review-name">
-                        総合評価：
-                      </span>
-                      <h3 class="top-review-value">
-                        <%= review.evaluation.name %>
-                      </h3>
-                      <span class="top-review-name">
-                        点
-                      </span>
-                    </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      ユーザー：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= review.user.nickname %>
+                    </h3>
+                  </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      メーカー：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= review.manufacture.name %>
+                    </h3>
+                  </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      総合評価：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= review.evaluation.name %>
+                    </h3>
+                    <span class="top-review-name">
+                      点
+                    </span>
                   </div>
                 </div>
-              <% end %>
-            </li>
-          <% end %>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
       <% else %>      
         <%# レビューがない場合のダミー %>
           <li class='list'>
             <%= link_to '#',class:"review-show-link" do %>
-            <div class='review-info'>
-              <div class='review-img-content'>
-                <%= image_tag "sample.png", class: "review-img" %>
+              <div class='review-info'>
+                <div class='review-img-content'>
+                  <%= image_tag "sample.png", class: "review-img" %>
+                </div>
+                <div class="top-review-detail">
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      商品名：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= "ここに商品名が表示されます" %>
+                    </h3>
+                  </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      ユーザー：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= "ここにニックネームが表示されます" %>
+                    </h3>
+                  </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      メーカー：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= "ここにメーカー名が表示されます" %>
+                    </h3>
+                  </div>
+                  <div class="top-review-group">
+                    <span class="top-review-name">
+                      総合評価（10点満点）：
+                    </span>
+                    <h3 class="top-review-value">
+                      <%= "ここに総合評価の点数が表示されます" %>
+                    </h3>
+                  </div>
+                </div>
               </div>
-              <div class="top-review-detail">
-                <div class="top-review-group">
-                  <span class="top-review-name">
-                    商品名：
-                  </span>
-                  <h3 class="top-review-value">
-                    <%= "ここに商品名が表示されます" %>
-                  </h3>
-                </div>
-                <div class="top-review-group">
-                  <span class="top-review-name">
-                    ユーザー：
-                  </span>
-                  <h3 class="top-review-value">
-                    <%= "ここにニックネームが表示されます" %>
-                  </h3>
-                </div>
-                <div class="top-review-group">
-                  <span class="top-review-name">
-                    メーカー：
-                  </span>
-                  <h3 class="top-review-value">
-                    <%= "ここにメーカー名が表示されます" %>
-                  </h3>
-                </div>
-                <div class="top-review-group">
-                  <span class="top-review-name">
-                    総合評価（10点満点）：
-                  </span>
-                  <h3 class="top-review-value">
-                    <%= "ここに総合評価の点数が表示されます" %>
-                  </h3>
-                </div>
-              </div>
-            </div>
             <% end %>
           </li>
         <%# //レビューがない場合のダミー %>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -1,11 +1,12 @@
 <%= render "shared/header" %>
 
 <div class="result-main">
-  <div class="result-content">
+
+  <%= render "shared/search_form" %>
+
+  <div class="right-wrapper">
     <div class="result-title-wrapper">
-      <h1 class="result-title">
-        検索結果
-      </h1>
+      <h1 class="result-title">検索結果</h1>
     </div>
     <ul class='review-lists'>
       <% if @results.length != 0 %>


### PR DESCRIPTION
# What
検索結果画面に検索フォームを設置した。

# Why
 修正前は
「検索結果画面から再び検索したいときは、またトップページに戻らなければならない」
という状態だった。
このままではユーザーにストレスがたまると考えたため、検索結果画面にも検索フォームを設置することで、すぐに検索を行うことができるようにした。