### PR TITLE
テストで使用するGemの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails', '~> 4.0.0'
+  gem 'rspec-rails'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,13 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
+    faker (2.13.0)
+      i18n (>= 1.6, < 2)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -285,6 +292,8 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  factory_bot_rails
+  faker
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   jquery-rails
@@ -296,7 +305,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rails_12factor
   ransack
-  rspec-rails (~> 4.0.0)
+  rspec-rails
   rubocop
   sass-rails (~> 5)
   selenium-webdriver


### PR DESCRIPTION
# What
テストで使用するGemの導入

具体的には以下3つを導入した。
- rspec-rails
- factory_bot_rails
- faker

# Why
テストコードを書き、アプリケーションが想定通りに動作することを確認するため。