### PR TITLE
nicknameカラムのバリデーションの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :like_reviews, through: :likes, source: :review
   has_one_attached :image
 
-  validates :nickname, presence: true, uniqueness: true ,length: {maximum: 10}
+  validates :nickname, presence: true, length: {maximum: 10}
   validates :self_introduction, length: {maximum: 200}
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,13 +41,6 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
 
-      it '重複したnicknameが存在する場合登録できないこと' do
-        @user.save
-        another_user = FactoryBot.build(:user, nickname: @user.nickname)
-        another_user.valid?
-        expect(another_user.errors.full_messages).to include('Nickname has already been taken')
-      end
-
       it 'emailに@が含まれていない場合、保存できないこと' do
         @user.email = 'sampletest.com'
         @user.valid?


### PR DESCRIPTION
# What
nicknameカラムのバリデーションの修正

具体的に言うと、ユーザーのニックネームは重複していても保存できるように変更した。

# Why
ゲストログイン機能の障害となるため、変更した。

※　まず、ゲストログイン機能は、「guest@example.com」というメールアドレスを持ったユーザーが存在すればそのユーザーをゲストユーザーとしてログインする。ここでメールアドレスのみを変更した上でログアウトし、再びゲストログインを行うと、「guest@example.com」というメールアドレスを持った「ゲストユーザー」という名前のユーザーが作成される。
　しかし、ここで「ニックネームは重複して存在できない」というバリデーションが働いていれば、1度目のゲストログインの時点で「ゲストユーザー」と言う名前のユーザーが作成されているため、2度目のゲストログイン機能は失敗してしまう。
　したがって、ユーザーのニックネームは重複していても保存できるようにバリデーションを変更することで、ゲストユーザー機能が働くようにした。