### PR TITLE
ゲストユーザーのパスワードを変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|
       user.nickname = "ゲストユーザー"
-      user.password = SecureRandom.urlsafe_base64
+      user.password = "password12345"
     end
   end
 end


### PR DESCRIPTION
# What
ゲストユーザーのパスワードを変更

# Why
ゲストログイン機能を正常に動作させるため。

※「SecureRandom.urlsafe_base64」をパスワードに使用すると、数字が含まれない文字列を生成することがある。
これでは「パスワードには英数字両方を含まなければならない」というバリデーション が働き、ゲストユーザーを登録することができない。したがって、現時点では「password12345」という文字列をパスワードとして設定した。