### PR TITLE
「config.assets.compile = true」に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
# What
config/environments/production.rb内の29行目にある「config.assets.compile = false」という記述を「config.assets.compile = true」に変更した。

# Why
本番環境上でアセットパイプラインを自動で通るようにすることで、Heroku上で使われる環境上のHTMLにCSSやJavaScriptを反映させるため。