### PR TITLE
「config.assets.initialize_on_precompile = false」を追記

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.assets.initialize_on_precompile = false
 end


### PR DESCRIPTION
# What
config/environments/production.rb内に「config.assets.initialize_on_precompile = false」という記述を追記した。

# Why
こちらも、本番環境上でアセットパイプラインを自動で通るようにすることで、Heroku上で使われる環境上のHTMLにCSSやJavaScriptを反映させるため。