### PR TITLE
開発環境で実装したメニューが本番環境（heroku）に反映されていないエラーの解消

### DIFF
--- a/app/assets/stylesheets/user/mypage.css.erb
+++ b/app/assets/stylesheets/user/mypage.css.erb
@@ -135,7 +135,7 @@
   padding: 20px;
   border-radius: 20px;
   cursor: pointer;
-  background-color: rgba(0,0,0);
+  background-color: rgba(0,0,255,0);
   border: 2px solid #1E90FF;
   color: #1E90FF;
   font-weight: bold;

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
@@ -109,5 +109,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.assets.initialize_on_precompile = false
 end


### PR DESCRIPTION
# What
フォローボタンに指定していた「  background-color: rgba(0,0,0);」という記述を「background-color: rgba(0,0,255,0);」に修正した。

# Why
フォローボタンに指定した「background-color: rgba(0,0,0);」という記述が、
「開発環境で実装したメニューが本番環境（heroku）に反映されていない」
というエラーを引き起こしているのだと考えたため。

※ 「git push heroku master」を実行したあとのログを遡って読むと、ターミナルで「Sass::SyntaxError: wrong number of arguments (3 for 4) for `rgba'」というエラーが発生していた。