### PR TITLE
本番環境（heroku）でマイページが表示されないエラーの解消

### DIFF
--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -1,6 +1,6 @@
 <% unless current_user == @user %>
   <% if current_user.following?(@user) %>
-    <%= form_with model: current_user.relationships.find_by(follow_id: @user.id), url: relationships_destroy_path(follow_id: @user.id), method: :delete, local: true do |f| %>
+    <%= form_with model: @user, url: relationships_destroy_path(follow_id: @user.id), method: :delete, local: true do |f| %>
       <%= f.hidden_field :follow_id, value: @user.id %>
       <%= f.submit 'フォロー中', class: 'unfollow-btn' %>
     <% end %>

--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -2,7 +2,7 @@
   <% if current_user.following?(@user) %>
     <%= form_with model: @user, url: relationships_destroy_path(follow_id: @user.id), method: :delete, local: true do |f| %>
       <%= f.hidden_field :follow_id, value: @user.id %>
-      <%= f.submit 'フォロー中', class: 'unfollow-btn' %>
+      <%= f.submit 'フォロー中', class: 'unfollow-btn', data: { confirm: "フォローを解除してもよろしいですか？" } %>
     <% end %>
   <% else %>
     <%= form_with model: current_user.relationships.build, url: relationships_create_path(follow_id: @user.id), local: true do |f| %>


### PR DESCRIPTION
# What
フォロー解除ボタンのform_withのmodelオプションで指定した
「current_user.relationships.find_by(follow_id: @user.id)」
という記述を「@user」に変更した。

# Why
フォロー解除ボタンのform_withのmodelオプションで指定した
「 current_user.relationships.find_by(follow_id: @user.id)」
という記述が、Heroku上で働かなかったのではないかと考えたため。