### PR TITLE
デフォルトのプロフィール画像のサイズ指定

### DIFF
--- a/app/assets/stylesheets/reviews/show.css.erb
+++ b/app/assets/stylesheets/reviews/show.css.erb
@@ -29,7 +29,7 @@
   font-size: 20px;
 }
 
-.show-user-image>img,.show-default-img>image {
+.show-user-image>img,.show-default-image>img {
   height: 50px;
   width: 50px;
   border-radius: 50%;


### PR DESCRIPTION
# What
デフォルトのプロフィール画像のサイズ指定

# Why
デフォルトのプロフィール画像のCSSを設定できていなかったため、セレクタを修正して再度設定を行った。