### PR TITLE
検索結果画面の編集（3回目）

### DIFF
--- a/app/assets/stylesheets/reviews/search-result.css.erb
+++ b/app/assets/stylesheets/reviews/search-result.css.erb
@@ -1,20 +1,20 @@
 .result-main {
-  padding: 50px 0;
+  padding: 40px 0;
   background-image: url("<%= asset_path("back-img.jpg") %>");
   background-size: cover;
   display: flex;
   justify-content: center;
-  min-height: 660px;
+  flex-direction: column;
   padding: 120px 0 50px;
 }
 
 .result-title-wrapper {
   text-align: center;
-  margin: 30px;
+  margin: 0 auto 40px;
 }
 
 .result-title {
-  font-size: 30px;
+  font-size: 25px;
   font-weight: bold;
 }
 
@@ -22,6 +22,14 @@
   height: 100px;
   width: 100%;
   display: flex;
-  text-align: center;
+  align-items: center;
   justify-content: center;
+}
+
+.back-btn {
+  background-color: #aaaaaa;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 30px;
+  padding: 15px 80px;
 }

--- a/app/assets/stylesheets/reviews/search-result.css.erb
+++ b/app/assets/stylesheets/reviews/search-result.css.erb
@@ -33,3 +33,23 @@
   border-radius: 30px;
   padding: 15px 80px;
 }
+
+@media screen and (max-width: 480px) {
+  .top-page-back {
+    height: 100px;
+    width: 80%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+  }
+
+  .back-btn {
+    background-color: #aaaaaa;
+    color: #ffffff;
+    text-decoration: none;
+    border-radius: 30px;
+    padding: 15px 40px;
+    font-size: 12px;
+  }
+}

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -2,11 +2,13 @@
 
 <div class="result-main">
 
-  <%= render "shared/search_form" %>
+  <div class="main-top">
+    <%= render "shared/search_form" %>
+  </div>
 
-  <div class="right-wrapper">
+  <div class="main-bottom">
     <div class="result-title-wrapper">
-      <h1 class="result-title">検索結果</h1>
+      <h1 class="result-title">- 検索結果 -</h1>
     </div>
     <ul class='review-lists'>
       <% if @results.length != 0 %>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -66,9 +66,11 @@
     </ul>
 
     <div class="top-page-back">
-      <div class="back-btn-wrap">
-        <%=link_to 'トップページにもどる', root_path, class: "back-button" %>
-      </div>
+      <%=link_to  root_path, class: "back-btn" do %>
+        <div class="back-btn-text">
+          トップページにもどる
+        </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# What
検索結果画面の編集
具体的には、
① 検索フォームを画面上側に配置し、検索結果を画面下側に配置した。（修正前は検索フォームを画面左側に配置し、検索結果を画面右側に配置していた）
② 「トップページにもどる」ボタンの修正とレスポンシブWebデザイン設定

# Why
①については、検索フォームのデザインや配置をトップページで修正したことにより、検索結果画面にレイアウトの崩れが見られたため。
②については、表示領域の横幅が480px以下になると、「トップページにもどる」ボタンの形が崩れてしまっていたため。