### PR TITLE
トップページと検索画面に見られるレイアウトの崩れの修正

### DIFF
--- a/app/assets/stylesheets/reviews/index.css.erb
+++ b/app/assets/stylesheets/reviews/index.css.erb
@@ -62,18 +62,19 @@
 .main-top {
   text-align: center;
   margin: 0 auto 50px;
-  width: 90%;
+  width: 960px;
   border: 2px solid #808080;
 }
 
 .main-bottom {
   margin: 0 auto;
   background-color: #ffffff;
-  width: 90%;
+  width: 960px;
   height: 100%;
-  padding: 40px 0;
+  padding: 40px 20px;
   background-color: #f5f5f5;
   border: 2px solid #808080;
+  vertical-align: baseline;
 }
 
 .review-lists-title {
@@ -89,16 +90,15 @@
 .review-lists {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
 }
 
 .list {
   list-style: none;
-  width: calc((100% - 150px) / 3);
   width: 280px;
   height: 280px;
-  margin-bottom: 25px;
+  margin-bottom: 30px;
 }
 
 .review-show-link {
@@ -160,3 +160,4 @@
   color: #ffffff;
   padding: 20px;
 }
+

--- a/app/assets/stylesheets/reviews/index.css.erb
+++ b/app/assets/stylesheets/reviews/index.css.erb
@@ -161,3 +161,87 @@
   padding: 20px;
 }
 
+@media screen and (max-width: 1024px) {
+  .main-top {
+    width: 650px;
+  }
+
+  .main-bottom {
+    width: 650px;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .main-top {
+    width: 400px;
+  }
+
+  .main-bottom {
+    width: 400px;
+  }
+
+  .review-lists {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  .main-top {
+    width: 300px;
+  }
+
+  .main-bottom {
+    width: 300px;
+  }
+
+  .review-lists {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+  }
+
+  .list {
+    width: 250px;
+    height: 250px;
+  }
+
+  .review-img-content>img {
+    width: 250px;
+    height: 250px;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .main-top {
+    width: 250px;
+  }
+
+  .main-bottom {
+    width: 250px;
+  }
+
+  .list {
+    width: 200px;
+    height: 200px;
+  }
+
+  .review-img-content>img {
+    width: 200px;
+    height: 200px;
+  }
+
+  .top-review-detail {
+    padding: 5px 10px;
+  }
+
+  .top-review-name, .top-review-value {
+    color: #ffffff;
+    font-size: 10px;
+  }
+}

--- a/app/assets/stylesheets/reviews/search-result.css.erb
+++ b/app/assets/stylesheets/reviews/search-result.css.erb
@@ -52,4 +52,13 @@
     padding: 15px 40px;
     font-size: 12px;
   }
+
+@media screen and (max-width: 320px) {
+  .top-page-back {
+    width: 90%;
+  }
+
+  .back-btn {
+    padding: 15px 20px;
+  }
 }

--- a/app/assets/stylesheets/shared/search-form.css
+++ b/app/assets/stylesheets/shared/search-form.css
@@ -68,16 +68,20 @@
 }
 
 .search-select {
-  margin: 5px auto;
+  margin: 20px auto;
   font-size: 16px;
 }
 
-#type-select>.search-select {
-  width: 70%;
+#type-select {
+  width: 35%;
 }
 
-#price-select>.search-select {
-  width: 70%;
+#manufacture-select {
+  width: 55%;
+}
+
+#price-select {
+  width: 43%;
 }
 
 .search-btn {
@@ -87,86 +91,3 @@
   margin-left: 10px;
 }
 
-@media screen and (max-width: 740px) {
-  #price-select>.search-select {
-    width: 90%;
-  }
-}
-
-@media screen and (max-width: 580px) {
-  .search-select-wrapper {
-    width: 100%;
-  }
-}
-
-@media screen and (max-width: 480px) {
-  .search-label {
-    height: 62px;
-  }
-
-  .search-group-wrapper {
-    display: block;
-  }
-  
-  .search-group {
-    width: 80%;
-    margin: 10px auto;
-  }
-
-  .search-select {
-    margin: 5px auto;
-  }
-
-  #type-select {
-    width: 43%;
-  }
-  
-  #manufacture-select {
-    width: 50%;
-  }
-
-  #price-select {
-    width: 43%;
-  }
-}
-
-@media screen and (max-width: 420px) {
-  #type-select {
-    width: 50%;
-  }
-  
-  #manufacture-select {
-    width: 60%;
-  }
-
-  #price-select {
-    width: 50%;
-}
-
-@media screen and (max-width: 365px) {
-  #type-select {
-    width: 55%;
-  }
-  
-  #manufacture-select {
-    width: 60%;
-  }
-
-  #price-select {
-    width: 55%;
-  }
-}
-
-@media screen and (max-width: 320px) {
-  #type-select {
-    width: 67%;
-  }
-  
-  #manufacture-select {
-    width: 77%;
-  }
-
-  #price-select {
-    width: 67%;
-  }
-}

--- a/app/assets/stylesheets/shared/search-form.css
+++ b/app/assets/stylesheets/shared/search-form.css
@@ -91,3 +91,67 @@
   margin-left: 10px;
 }
 
+@media screen and (max-width: 1024px) {
+  #type-select {
+    width: 50%;
+  }
+  
+  #manufacture-select {
+    width: 80%;
+  }
+  
+  #price-select {
+    width: 65%;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .search-group-wrapper {
+    display: block;
+  }
+  
+  .search-group {
+    width: 80%;
+    margin: 10px auto;
+  }
+
+  #type-select {
+    width: 30%;
+  }
+  
+  #manufacture-select {
+    width: 50%;
+  }
+
+  #price-select {
+    width: 37%;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  #type-select {
+    width: 39%;
+  }
+  
+  #manufacture-select {
+    width: 65%;
+  }
+
+  #price-select {
+    width: 50%;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  #type-select {
+    width: 47%;
+  }
+  
+  #manufacture-select {
+    width: 80%;
+  }
+
+  #price-select {
+    width: 60%;
+  }
+}

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -25,7 +25,7 @@
 
     <div class="main-bottom">
       <div class="review-lists-title">
-        <h2 class="new-review-title">- 最新レビュー一覧 -</h2>
+        <h2 class="new-review-title">- 最新レビュー -</h2>
       </div>
 
       <%= render "shared/reviews" %>


### PR DESCRIPTION
# What
トップページと検索画面に見られるレイアウトの崩れの修正
具体的には、
「トップページと検索画面において、ブラウザの表示領域の横幅が310px以下だとレビューが親要素からはみ出た状態で表示されてしまう」
という問題を解決するため、トップページと検索画面をレスポンシブ化させた。

# Why
表示領域の横幅が310px以下のスマートフォンを使用するユーザーにとって、「操作しづらい」「サービスの見栄えが悪い」といった問題点があるため。