### PR TITLE
}の抜けを修正

### DIFF
--- a/app/assets/stylesheets/reviews/search-result.css.erb
+++ b/app/assets/stylesheets/reviews/search-result.css.erb
@@ -52,6 +52,7 @@
     padding: 15px 40px;
     font-size: 12px;
   }
+}
 
 @media screen and (max-width: 320px) {
   .top-page-back {


### PR DESCRIPTION
# What
37行目の
「@media screen and (max-width: 480px) {」
に対応した、閉じの「}」がなかったため、修正した。

# Why
自動デプロイを行ったところ、変更内容が本番環境に反映されていなかったため。
（その後、ターミナルを確認したところ、「Sass::SyntaxError: Invalid CSS after "  width: auto; }": expected "}",…」というエラーが発生していたことから、CSSに問題があることがわかった）