### PR TITLE
searchアクションにmove_to_indexメソッドが適用されないように設定

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,6 @@
 class ReviewsController < ApplicationController
   before_action :exist_review?, only: [:show, :edit, :update, :destroy]
-  before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show, :search]
   before_action :set_review, only: [:show, :edit, :update, :destroy]
   before_action :search_review, only: [:index, :search]
 


### PR DESCRIPTION
# What
searchアクションにmove_to_indexメソッドが適用されないように設定

# Why
move_to_indexメソッドがsearchアクションに適用されないように設定したのは、ログインしなくてもレビュー検索機能を利用可能にしたいため。
（「move_to_indexメソッド」とは、ユーザーがログインしていなければトップページにリダイレクトさせるよう定義したメソッドである。）