### PR TITLE
プレビュー機能により表示される画像をレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/reviews/preview.css
+++ b/app/assets/stylesheets/reviews/preview.css
@@ -1,6 +1,26 @@
+#image-list>div {
+  text-align: center;
+}
+
 #image-list>div>img {
-  height: 300px;
-  width: 300px;
+  height: 400px;
+  width: 400px;
   object-fit: contain;
-  margin: 30px;
+  margin: 30px auto;
+}
+
+@media screen and (max-width: 959px) {
+    #image-list>div>img {
+    height: 250px;
+    width: 250px;
+    object-fit: contain;
+  }
+}
+
+@media screen and (max-width: 559px) {
+    #image-list>div>img {
+    height: 180px;
+    width: 180px;
+    object-fit: contain;
+  }
 }


### PR DESCRIPTION
# What
プレビュー機能により表示される画像をレスポンシブ化させた。
具体的には、新規投稿画面のブレイクポイント（横幅が959px以下の時と559px以下の時）に合わせて、表示される画像のCSSを設定し直した。

# Why
横幅を559px以下に設定した時に見られる、レイアウトの崩れを解決するため。

※ 補足：Chromeの検証機能でモバイル表示（横幅を559px以下に設定した時）にして新規投稿画面を閲覧すると、プレビュー機能により表示される画像が親要素をはみ出てしまうためにレイアウトが崩れてしまう。これを解決するために、Whatに記述した通り、画像をレスポンシブ対応化させた。