### PR TITLE
ユーザーのプロフィール編集ページをレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/user/mypage.css.erb
+++ b/app/assets/stylesheets/user/mypage.css.erb
@@ -29,11 +29,11 @@
 <%# ユーザー名 %>
 
 <%# プロフィール編集ボタン %>
-.profile-edit-btn {
+.profile-edit-link {
   text-decoration: none;
 }
 
-.profile-edit-btn-wrapper {
+.profile-edit-link-wrapper {
   width: 100%;
   height: 70px;
   display: flex;

--- a/app/assets/stylesheets/user/profile-edit.css.erb
+++ b/app/assets/stylesheets/user/profile-edit.css.erb
@@ -4,16 +4,16 @@
   background-size: cover;
   display: flex;
   justify-content: center;
-  align-items: center;
-  min-height: 100vh;
+  min-height: calc(100vh - 50px);
 }
 
 .profile-edit-form-wrapper {
-  width: 60%;
-  margin: auto;
+  width: 700px;
+  margin: 0 auto;
 }
 
 .form-wrapper {
+  height: 750px;
   margin: 0 auto;
   background-color: #ffffff;
   padding: 40px;

--- a/app/assets/stylesheets/user/profile-edit.css.erb
+++ b/app/assets/stylesheets/user/profile-edit.css.erb
@@ -18,7 +18,7 @@
 }
 
 .form-wrapper {
-  height: 630px;
+  height: 100%;
   margin: 0 auto;
   background-color: #ffffff;
   padding: 40px;
@@ -60,4 +60,36 @@
   border-radius: 30px;
   color: #ffffff;
   background-color: #000000;
+}
+
+@media screen and (max-width: 959px) {
+  .profile-edit-form-wrapper {
+    width: 450px;
+  }
+
+  .edit-form-text {
+    font-size: 16px;
+  }
+}
+
+@media screen and (max-width: 559px) {
+  .profile-edit-form-wrapper {
+    width: 313px;
+  }
+
+  .edit-form-header-text {
+    font-size: 20px;
+  }
+
+  .edit-form-text {
+    font-size: 12px;
+  }
+
+  .profile-edit-btn {
+    padding: 15px 65px;
+  }
+
+  .input-default {
+    font-size: 12px;
+  }
 }

--- a/app/assets/stylesheets/user/profile-edit.css.erb
+++ b/app/assets/stylesheets/user/profile-edit.css.erb
@@ -5,7 +5,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 660px;
+  min-height: 100vh;
 }
 
 .profile-edit-form-wrapper {
@@ -13,7 +13,7 @@
   margin: auto;
 }
 
-.form-wrap {
+.form-wrapper {
   margin: 0 auto;
   background-color: #ffffff;
   padding: 40px;
@@ -26,4 +26,17 @@
 #self_introduction {
   margin-top: 10px;
   resize: none;
+}
+
+.profile-edit-btn-wrapper {
+  margin-top: 50px;
+  text-align: center;
+}
+
+.profile-edit-btn {
+  padding: 15px 125px;
+  border: none;
+  border-radius: 30px;
+  color: #ffffff;
+  background-color: #000000;
 }

--- a/app/assets/stylesheets/user/profile-edit.css.erb
+++ b/app/assets/stylesheets/user/profile-edit.css.erb
@@ -12,8 +12,13 @@
   margin: 0 auto;
 }
 
+.edit-form-header-text {
+  font-size: 25px;
+  font-weight: bold;
+}
+
 .form-wrapper {
-  height: 750px;
+  height: 630px;
   margin: 0 auto;
   background-color: #ffffff;
   padding: 40px;
@@ -21,6 +26,22 @@
 
 #preview-image {
   margin-top: 10px;
+}
+
+.edit-input-default {
+  width: 100%;
+  margin-top: 10px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #c0c0c0;
+  background: #fff;
+  font-size: 16px;
+  resize: none;
+}
+
+.edit-form-text {
+  font-size: 20px;
+  font-weight: bold;
 }
 
 #self_introduction {

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,10 +3,10 @@
 <div class="profile-edit-main">
   <div class="profile-edit-form-wrapper">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, class:"profile-edit-form") do |f| %>
-      <div class="form-wrap">
+      <div class="form-wrapper">
         <div class="form-header">
             <h1 class="form-header-text">
-              ユーザー情報編集
+              - ユーザー情報編集 -
             </h1>
         </div>
 
@@ -42,8 +42,8 @@
           <div id="image-list"></div>
         </div>
 
-        <div class='register-btn'>
-          <%= f.submit "編集する" ,class:"register-button" %>
+        <div class='profile-edit-btn-wrapper'>
+          <%= f.submit "編集する" ,class:"profile-edit-btn" %>
         </div>
       </div>
     <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, class:"profile-edit-form") do |f| %>
       <div class="form-wrapper">
         <div class="form-header">
-            <h1 class="form-header-text">
+            <h1 class="edit-form-header-text">
               - ユーザー情報編集 -
             </h1>
         </div>
@@ -14,21 +14,21 @@
 
         <div class="form-group">
           <div class="form-text-wrap">
-            <label class="form-text">ニックネーム(10文字以内)</label>
+            <label class="edit-form-text">ニックネーム(10文字以内)</label>
           </div>
-          <%= f.text_area :nickname, class: "input-default", id: "nickname", placeholder: "ニックネーム【10文字以内】", maxlength: "10",  autofocus: true %>
+          <%= f.text_area :nickname, class: "edit-input-default", id: "nickname", placeholder: "ニックネーム【10文字以内】", rows: "1", maxlength: "10",  autofocus: true %>
         </div>
 
         <div class="form-group">
           <div class="form-text-wrap">
-            <label class="form-text">メールアドレス</label>
+            <label class="edit-form-text">メールアドレス</label>
           </div>
-          <%= f.email_field :email, class: "input-default", id: "email", placeholder: "メールアドレス", autofocus: true %>
+          <%= f.email_field :email, class: "edit-input-default", id: "email", placeholder: "メールアドレス", autofocus: true %>
         </div>
 
         <div class="form-group">
           <div class="form-text-wrap">
-            <label class="form-text">プロフィール画像</label>
+            <label class="edit-form-text">プロフィール画像</label>
           </div>
           <%= f.file_field :image, autofocus: true, id:"preview-image" %>
           <div id="image-list"></div>
@@ -36,9 +36,9 @@
 
         <div class="form-group">
           <div class="form-text-wrap">
-            <label class="form-text">自己紹介（200字以内）</label>
+            <label class="edit-form-text">自己紹介（200字以内）</label>
           </div>
-          <%= f.text_area :self_introduction, id: "self_introduction", placeholder: "自己紹介文を入力してください（200字以内）", rows: "5", maxlength: "200", autofocus: true %>
+          <%= f.text_area :self_introduction, id: "self_introduction", placeholder: "自己紹介文を入力してください（200字以内）", rows: "3", maxlength: "200", autofocus: true %>
           <div id="image-list"></div>
         </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -92,8 +92,8 @@
 
     <div class="link-buttons">
       <% if user_signed_in? && (current_user.id == @user.id) %>
-        <%= link_to edit_user_registration_path(current_user.id), class:"profile-edit-btn" do %>
-          <div class="profile-edit-btn-wrapper">
+        <%= link_to edit_user_registration_path(current_user.id), class:"profile-edit-link" do %>
+          <div class="profile-edit-link-wrapper">
             <i class="fas fa-user-edit link-btns"></i> ユーザー情報編集
           </div>
         <% end %>


### PR DESCRIPTION
＃What
ユーザーのプロフィール編集ページをレスポンシブ化
ブレイクポイントを「横幅が559pxの時」と「横幅が959pxの時」に分けてCSSを設定した。

# Why
タブレットやスマートフォンを使用しているユーザーにも見やすいデザインとするため。