### PR TITLE
トップページ・ヘッダーメニューの修正

### DIFF
--- a/app/assets/stylesheets/reviews/index.css.erb
+++ b/app/assets/stylesheets/reviews/index.css.erb
@@ -49,7 +49,7 @@
   word-wrap: normal;
 }
 
-.guest-login {
+.guest-login-btn {
   margin-left: 10px;
   color: #00ffff;
   text-decoration: none;
@@ -181,7 +181,7 @@
     bottom: 40px;
   }
 
-  .guest-login {
+  .guest-login-btn {
     position: absolute;
     left: 0px;
     bottom: -30px;

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -137,19 +137,19 @@ font-size: 30px;
   background-color: #ffffff;
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 959px) {
   .header-logo h1 {
     font-size: 25px;
+  }
+}
+
+@media screen and (max-width: 559px) {
+  .header-logo h1 {
+    font-size: 20px;
   }
 
   .open-menu {
     width: 100%;
-  }
-}
-
-@media screen and (max-width: 320px) {
-  .header-logo h1 {
-    font-size: 20px;
   }
 
   .menu-wrapper {

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -12,7 +12,7 @@
       <% unless user_signed_in? %>
         <div class="service-guest-login">
           <p>ポートフォリオ用にゲストログイン機能を実装しております。</p>
-          <%= link_to "ゲストログイン（閲覧用）",users_guest_sign_in_path, method: :post, class: "guest-login" %>
+          <%= link_to "ゲストログイン（閲覧用）",users_guest_sign_in_path, method: :post, class: "guest-login-btn" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
# What
トップページ・ヘッダーメニューの修正を行った。
具体的には
①トップページのサービス説明欄にあるゲストログインボタンのクラス名を変更した。
②ヘッダーのブレイクポイントを「ブラウザの表示領域の横幅が959px以下の時」と「559px以下の時」の2つに分けた。

# Why
①については、ヘッダーメニューにあるゲストログインボタンと、トップページのサービス説明欄にあるゲストログインボタンのクラス名が全く同じもの（クラス名：guest-login）であり、それが原因でヘッダーメニューにある方のゲストログインボタンのレイアウトが崩れていたため。
②については、ヘッダー以外の要素のブレイクポイントを「ブラウザの表示領域の横幅が959px以下の時」と「559px以下の時」の2つに分けており、こちらに統一した方が見やすいデザインになると考えたため。