### PR TITLE
レビュー詳細画面のレスポンシブ化が本番環境に反映されない問題の解決

### DIFF
--- a/app/assets/stylesheets/reviews/show.css.erb
+++ b/app/assets/stylesheets/reviews/show.css.erb
@@ -103,7 +103,6 @@
   border-radius: 20px 20px 0 0;
   margin: 30px auto;
   border: 1px solid #dedede;
-  width: 700px;
 }
 
 .detail-content {
@@ -189,16 +188,12 @@
     width: 500px;
   }
 
-  .product-info,.user-evaluation {
+  .product-info,.user-evaluation,.product-content {
     width: 440px;
   }
 
   .review-buttons {
     width: 80%;
-  }
-
-  .product-content {
-    width: 440px;
   }
 
   .video-wrapper {
@@ -243,10 +238,6 @@
 
   .edit-btn {
     margin-bottom: 30px;
-  }
-
-  .edit-btn-wrapper.delete-btn-wrapper {
-    width: ;
   }
 
   .detail-product,.detail-value {


### PR DESCRIPTION
# What
レビュー詳細画面のレスポンシブ化が本番環境に反映されない問題の解決
具体的には、CSSファイルに記述していた不要な記述の削除

# Why
CSSファイルに記述されていた不要な記述が原因で、レスポンシブ化本番環境に反映されていないと考えたため。
（ターミナルで自動デプロイを実行した際に、「Sass::SyntaxError: Invalid CSS after "    width: ": expected expression (e.g. 1px, bold), was ";"」というエラーメッセージが表示された。このことから、width（横幅）に関するCSSにミスがないかをを調べたところ、「width: ;」という値が指定されていない記述があったため、削除した）