### PR TITLE
プロフィール画面の編集

### DIFF
--- a/app/assets/stylesheets/user/profile-page.css.erb
+++ b/app/assets/stylesheets/user/profile-page.css.erb
@@ -13,6 +13,7 @@
   width: 700px;
   margin: 0 auto;
   border: 1px solid #000000;
+  border-radius: 20px 20px 0 0;
 }
 
 .profile-header {
@@ -77,6 +78,7 @@
   background-color: #000000;
   padding: 30px 15px;
   position: relative;
+  border-radius: 20px 20px 0 0;
 }
 
 .image-and-name {

--- a/app/assets/stylesheets/user/profile-page.css.erb
+++ b/app/assets/stylesheets/user/profile-page.css.erb
@@ -75,7 +75,7 @@
   height: 100%;
   width: 100%;
   background-color: #000000;
-  padding: 30px;
+  padding: 30px 15px 15px;
   position: relative;
 }
 
@@ -279,6 +279,10 @@
     padding: 30px 15px;
   }
 
+  .image-and-name {
+    width: 100%;
+  }
+
   .profile-image>img {
     height: 90px;
     width: 90px;
@@ -316,10 +320,6 @@
     position: absolute;
     top: 183px;
     right: 15px;
-  }
-
-  .image-and-name {
-    width: 100px;
   }
 
   .follow-btn,.unfollow-btn {

--- a/app/assets/stylesheets/user/profile-page.css.erb
+++ b/app/assets/stylesheets/user/profile-page.css.erb
@@ -75,12 +75,12 @@
   height: 100%;
   width: 100%;
   background-color: #000000;
-  padding: 30px 15px 15px;
+  padding: 30px 15px;
   position: relative;
 }
 
 .image-and-name {
-  width: 150px;
+  width: 100%;
   margin-bottom: 15px;
 }
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -17,7 +17,7 @@ class Review < ApplicationRecord
 
   HALF_WIDTH_NUMBER_REGEX = /\A[0-9]+\z/.freeze
 
-  select = "は「--」以外の項目を選択してください"
+  select = 'は「--」以外の項目を選択してください'
 
   with_options presence: true do
     validates :image

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
         </div>
       </div>
       <%# 自己紹介文 %>
-        <% if @user.self_introduction %>
+        <% if @user.self_introduction.present? %>
           <div class="self-introduction-wrapper">
             <p class="self-introduction">
               <%= @user.self_introduction %>


### PR DESCRIPTION
# What
- 自己紹介文は、ユーザーに設定されている場合のみ余白も含めて表示する（以前は自己紹介文が設定されていなくても、余白のみが表示されていたりした）。
- 要素の横幅や余白の調整
- プロフィールの上側の角を丸い形に設定した。

# Why
ユーザーにとって見やすいデザインとするため。