### PR TITLE
ユーザーの新規登録に関する単体テストコードの追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,9 @@ class User < ApplicationRecord
 
   validates :nickname, presence: true, length: { maximum: 10 }
   validates :self_introduction, length: { maximum: 200 }
+  
+  EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  validates :email, format: {with: EMAIL_REGEX }
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX, message: 'は英字と数字の両方を含めて6文字以上のものを設定してください', on: :create

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Email can't be blank")
       end
 
+      it 'emailに全角が含まれていると登録できないこと' do
+        @user.email = 'サンプル@gmail.com'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Email is invalid")
+      end
+
       it 'passwordが空では登録できないこと' do
         @user.password = nil
         @user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,12 +41,6 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Password can't be blank")
       end
 
-      it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
-        @user.password_confirmation = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-      end
-
       it 'emailに@が含まれていない場合、保存できないこと' do
         @user.email = 'sampletest.com'
         @user.valid?
@@ -79,6 +73,12 @@ RSpec.describe User, type: :model do
         @user.password_confirmation = '123456'
         @user.valid?
         expect(@user.errors.full_messages).to include('Password は英字と数字の両方を含めて6文字以上のものを設定してください')
+      end
+      
+      it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
     end
   end


### PR DESCRIPTION
# What
ユーザーの新規登録に関する単体テストコードの追加
具体的には、
- メールアドレスは「半角英数字や『.』『-』を1文字以上 + @ + 半角英数字や『.』『-』を1文字以上」でないと保存できないというバリデーションを設定した。
- 「メールアドレスの入力を全角では行うことができないというテストを追加した。

# Why
「メールアドレスを全角を含んだ状態で保存できてしまう」という事態は致命的だと考えたため。