### PR TITLE
ニックネームの文字数を30文字以内に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ http://18.180.35.109/
 
 　そこで、私は「ラバーの性能についてわかるサービスがあれば、ラバー選びに関する悩みが減るのではないか」と考え、このサービスを制作しました。
 
-# DEMO
-今後追加予定
-
 # 機能一覧
 
 - ログイン機能
@@ -55,6 +52,7 @@ http://18.180.35.109/
 | nickname             | string  | null: false |
 | email                | string  | null: false |
 | password             | string  | null: false |
+|self_introduction     | text    |             |
 
 ### Association
 
@@ -79,6 +77,7 @@ http://18.180.35.109/
 | content             | text       | null: false                    |
 | likes_count         | integer    | null: false                    |
 | comments_count      | integer    | null: false                    |
+| video               | string     |                                |
 | user                | references | null: false, foreign_key: true |
 
 ### Association
@@ -112,3 +111,15 @@ http://18.180.35.109/
 
 - belongs_to :user
 - belongs_to :review
+
+## relationshipsテーブル
+
+| Column              | Type       | Options                                       |
+| ------------------- | ---------- | --------------------------------------------- |
+| user                | references | null: false, foreign_key: true                |
+| follow              | references | null: false, foreign_key: {to_table: :users}  |
+
+### Association
+
+- belongs_to :user
+- belongs_to :follow

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :followers, through: :reverse_of_relationships, source: :user
   has_one_attached :image
 
-  validates :nickname, presence: true, length: { maximum: 10 }
+  validates :nickname, presence: true, length: { maximum: 30 }
   validates :self_introduction, length: { maximum: 200 }
 
   EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,9 +14,9 @@
 
         <div class="form-group">
           <div class="form-text-wrap">
-            <label class="edit-form-text">ニックネーム(10文字以内)</label>
+            <label class="edit-form-text">ニックネーム(30文字以内)</label>
           </div>
-          <%= f.text_area :nickname, class: "edit-input-default", id: "nickname", placeholder: "ニックネーム【10文字以内】", rows: "1", maxlength: "10",  autofocus: true %>
+          <%= f.text_area :nickname, class: "edit-input-default", id: "nickname", placeholder: "ニックネーム【30文字以内】", rows: "1", maxlength: "30",  autofocus: true %>
         </div>
 
         <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,9 +16,9 @@
 
           <div class="form-group">
             <div class="form-text-wrap">
-              <label class="form-text">ニックネーム(10文字以内)</label>
+              <label class="form-text">ニックネーム(30文字以内)</label>
             </div>
-            <%= f.text_area :nickname, class: "input-default", id: "nickname", placeholder: "ニックネーム", maxlength: "10" %>
+            <%= f.text_area :nickname, class: "input-default", id: "nickname", placeholder: "ニックネーム", maxlength: "30" %>
           </div>
 
           <div class="form-group">

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Nickname can't be blank")
       end
 
-      it 'nicknameが11文字以上であれば登録できないこと' do
-        @user.nickname = 'ニックネームが11文字'
+      it 'nicknameの文字数がが30文字より多ければ登録できないこと' do
+        @user.nickname = 'ユーザーのニックネームは30文字以内に収めなければ登録できない'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Nickname is too long (maximum is 10 characters)')
+        expect(@user.errors.full_messages).to include('Nickname is too long (maximum is 30 characters)')
       end
 
       it 'emailが空では登録できないこと' do


### PR DESCRIPTION
# What
ニックネームの文字数を30文字以内に変更した。

# Why
ニックネームの文字数の入力が10文字以内では使い勝手が悪いと感じたため。