### PR TITLE
その他コメントの文字数制限に関するテストを追加

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -30,7 +30,7 @@ class Review < ApplicationRecord
     validates :hardness_id,    numericality: { other_than: 1, message: select }
     validates :evaluation_id,  numericality: { other_than: 1, message: select }
     validates :price,          format: { with: HALF_WIDTH_NUMBER_REGEX, message: 'は半角数字で入力してください' }, numericality: { greater_than: 0, message: 'は0より大きい半角数字で入力してください' }
-    validates :content
+    validates :content, length: { maximum: 1000 }
   end
 
   def like_user(user_id)

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Review, type: :model do
         expect(@review.errors.full_messages).to include("Content can't be blank")
       end
 
+      it 'contentが1000字より多いと投稿できないこと' do
+        @review.content = "a" * 1001
+        @review.valid?
+        expect(@review.errors.full_messages).to include("Content is too long (maximum is 1000 characters)")
+      end
+
       it 'manufactureは「--」を選択すると投稿できないこと' do
         @review.manufacture_id = 1
         @review.valid?


### PR DESCRIPTION
# What
「その他コメントは1000文字まで入力することができる」というテストを追加

# Why
文字数制限に関するテストが抜けていたため。