### PR TITLE
DatabaseCleanerの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'factory_bot_rails'
-  gem 'database_cleaner'
   gem 'faker'
   gem 'capistrano'
   gem 'capistrano-rbenv'
@@ -60,6 +59,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+  gem 'database_cleaner-active_record'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
-    database_cleaner (1.3.0)
+    database_cleaner (1.8.5)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -373,7 +376,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara
-  database_cleaner
+  database_cleaner-active_record
   devise
   factory_bot_rails
   faker


### PR DESCRIPTION
# What
DatabaseCleanerの実装（Gemのdatabase_cleaner-active_recordをインストール）

# Why
修正前はdatabase_cleanerというGemをインストールしていたが、こちらではエラーが発生したため。
また、DatabaseCleanerの公式ドキュメントを改めて確認したところ、インストールするべきGemがdatabase_cleaner-active_recordであることが判明したため。