### PR TITLE
インスタンス変数をletを用いた記述に置き換え

### DIFF
--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :review do
+    image { Rack::Test::UploadedFile.new('public/images/test.jpg', 'image/jpg') }
     name { Faker::Name.name }
     manufacture_id { 2 }
     type_id { 2 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
 
     context '新規登録できない場合' do
       it 'nicknameが空では登録できないこと' do
-        use.nickname = nil
+        user.nickname = nil
         user.valid?
         expect(user.errors.full_messages).to include("Nickname can't be blank")
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,83 +2,83 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'ユーザーの新規登録' do
-    before do
-      @user = FactoryBot.build(:user)
-    end
+    let(:user) { FactoryBot.build(:user) }
+
     context '新規登録できる場合' do
       it 'nickname、email、password、password_confirmationが存在すれば登録できること' do
-        expect(@user).to be_valid
+        expect(user).to be_valid
       end
     end
+
     context '新規登録できない場合' do
       it 'nicknameが空では登録できないこと' do
-        @user.nickname = nil
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        use.nickname = nil
+        user.valid?
+        expect(user.errors.full_messages).to include("Nickname can't be blank")
       end
 
       it 'nicknameの文字数がが30文字より多ければ登録できないこと' do
-        @user.nickname = 'ユーザーのニックネームは30文字以内に収めなければ登録できない'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Nickname is too long (maximum is 30 characters)')
+        user.nickname = 'ユーザーのニックネームは30文字以内に収めなければ登録できない'
+        user.valid?
+        expect(user.errors.full_messages).to include('Nickname is too long (maximum is 30 characters)')
       end
 
       it 'emailが空では登録できないこと' do
-        @user.email = nil
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        user.email = nil
+        user.valid?
+        expect(user.errors.full_messages).to include("Email can't be blank")
       end
 
       it 'emailに全角が含まれていると登録できないこと' do
-        @user.email = 'サンプル@gmail.com'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        user.email = 'サンプル@gmail.com'
+        user.valid?
+        expect(user.errors.full_messages).to include('Email is invalid')
       end
 
       it 'passwordが空では登録できないこと' do
-        @user.password = nil
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        user.password = nil
+        user.valid?
+        expect(user.errors.full_messages).to include("Password can't be blank")
       end
 
       it 'emailに@が含まれていない場合、保存できないこと' do
-        @user.email = 'sampletest.com'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        user.email = 'sampletest.com'
+        user.valid?
+        expect(user.errors.full_messages).to include('Email is invalid')
       end
 
       it '重複したemailが存在する場合登録できないこと' do
-        @user.save
-        another_user = FactoryBot.build(:user, email: @user.email)
+        user.save
+        another_user = FactoryBot.build(:user, email: user.email)
         another_user.valid?
         expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
 
       it 'passwordが5文字以下であれば登録できないこと' do
-        @user.password = 'a1234'
-        @user.password_confirmation = 'a1234'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        user.password = 'a1234'
+        user.password_confirmation = 'a1234'
+        user.valid?
+        expect(user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
       end
 
       it 'passwordが英字のみなら保存できないこと' do
-        @user.password = 'aaaaaa'
-        @user.password_confirmation = 'aaaaaa'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Password は英字と数字の両方を含めて6文字以上のものを設定してください')
+        user.password = 'aaaaaa'
+        user.password_confirmation = 'aaaaaa'
+        user.valid?
+        expect(user.errors.full_messages).to include('Password は英字と数字の両方を含めて6文字以上のものを設定してください')
       end
 
       it 'passwordが数字のみなら保存できないこと' do
-        @user.password = '123456'
-        @user.password_confirmation = '123456'
-        @user.valid?
-        expect(@user.errors.full_messages).to include('Password は英字と数字の両方を含めて6文字以上のものを設定してください')
+        user.password = '123456'
+        user.password_confirmation = '123456'
+        user.valid?
+        expect(user.errors.full_messages).to include('Password は英字と数字の両方を含めて6文字以上のものを設定してください')
       end
 
       it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
-        @user.password_confirmation = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        user.password_confirmation = ''
+        user.valid?
+        expect(user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
     end
   end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -1,12 +1,8 @@
 require 'rails_helper'
-describe ReviewsController, type: :request do
-  before do
-    @review = FactoryBot.build(:review)
-    @review.image = fixture_file_upload('public/images/test.jpg')
-    @review.save
-  end
-
+RSpec.describe ReviewsController, type: :request do
   describe 'GET #index' do
+    let!(:review) {FactoryBot.create(:review) }
+
     it 'indexアクションにリクエストすると正常にレスポンスが返ってくる' do
       get root_path
       expect(response.status).to eq 200
@@ -14,79 +10,86 @@ describe ReviewsController, type: :request do
 
     it 'indexアクションにリクエストするとレスポンスに投稿済みのレビューの商品名が表示されている' do
       get root_path
-      expect(response.body).to include @review.name
+      expect(response.body).to include review.name
     end
-
+    
     it 'indexアクションにリクエストするとレスポンスに投稿済みのレビューの投稿者名が表示されている' do
       get root_path
-      expect(response.body).to include @review.user.nickname
+      expect(response.body).to include review.user.nickname
     end
 
     it 'indexアクションにリクエストするとレスポンスに投稿済みのレビューのメーカー名が表示されている' do
       get root_path
-      expect(response.body).to include @review.manufacture.name
+      expect(response.body).to include review.manufacture.name
     end
 
     it 'indexアクションにリクエストするとレスポンスに投稿済みのレビューの総合評価点数が表示されている' do
       get root_path
-      expect(response.body).to include @review.evaluation.name
+      expect(response.body).to include review.evaluation.name
     end
   end
 
   describe 'GET #show' do
+    let!(:review){ FactoryBot.create(:review) }
+
     it "showアクションにリクエストすると正常にレスポンスが返ってくる" do 
-      get review_path(@review)
+      get review_path(review)
       expect(response.status).to eq 200
     end
 
     it 'showアクションにリクエストするとレスポンスにレビューの投稿者名が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.user.nickname
+      get review_path(review)
+      expect(response.body).to include review.user.nickname
     end
 
-    it 'showアクションにリクエストするとレスポンスに商品名が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.manufacture.name
+    it 'showアクションにリクエストするとレスポンスにレビューの商品名が表示されている' do
+      get review_path(review)
+      expect(response.body).to include review.name
+    end
+
+    it 'showアクションにリクエストするとレスポンスにメーカー名が表示されている' do
+      get review_path(review)
+      expect(response.body).to include review.manufacture.name
     end
 
     it 'showアクションにリクエストするとレスポンスにラバーの種類が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.type.name
+      get review_path(review)
+      expect(response.body).to include review.type.name
     end
 
     it 'showアクションにリクエストするとレスポンスに打球感が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.hardness.name
+      get review_path(review)
+      expect(response.body).to include review.hardness.name
     end
 
     it 'showアクションにリクエストするとレスポンスに価格が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.price.to_s
+      get review_path(review)
+      expect(response.body).to include review.price.to_s
     end
 
     it 'showアクションにリクエストするとレスポンスにスピード性能の点数が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.speed.name
+      get review_path(review)
+      expect(response.body).to include review.speed.name
     end
 
     it 'showアクションにリクエストするとレスポンスにスピン性能の点数が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.spin.name
+      get review_path(review)
+      expect(response.body).to include review.spin.name
     end
 
     it 'showアクションにリクエストするとレスポンスにコントロール性能の点数が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.control.name
+      get review_path(review)
+      expect(response.body).to include review.control.name
     end
 
     it 'showアクションにリクエストするとレスポンスに総合評価の点数が表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.evaluation.name
+      get review_path(review)
+      expect(response.body).to include review.evaluation.name
     end
 
     it 'showアクションにリクエストするとレスポンスにその他コメントが表示されている' do
-      get review_path(@review)
-      expect(response.body).to include @review.content
+      get review_path(review)
+      expect(response.body).to include review.content
     end
   end
 end


### PR DESCRIPTION
# What
インスタンス変数をletを用いた記述に置き換え

# Why
letを用いた記述には、次のようなメリットがあるため。
- typoに気付きやすい
- ローカル変数をそのままletに置き換えることができる
- 無駄な初期化をなくせる（時間の短縮）
- テストが見やすくなる