### PR TITLE
Commentsコントローラーの単体テストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'rubocop', require: false
   gem 'bundle_outdated_formatter'
+  gem 'spring-commands-rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -398,6 +400,7 @@ DEPENDENCIES
   sass-rails (~> 5)
   selenium-webdriver
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   unicorn (= 5.4.1)

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     association :user
     association :review
   end
+
+  # コメントが空の場合
+  trait :invalid do
+    content = nil
+    content { content }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   config.after(:all) do
     DatabaseCleaner.clean
   end
+
+  # コントローラースペックで Devise のテストヘルパーを使用する
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe CommentsController, type: :controller do
 
     it 'コメントを投稿できないこと' do
       comment_params = FactoryBot.attributes_for(:comment, :invalid)
-        sign_in user
-        expect {
-          post :create, format: ["text/html"], params: { review_id: review.id, comment: comment_params }
-        }.to_not change(user.comments, :count)
+      sign_in user
+      expect {
+        post :create, format: ["text/html"], params: { review_id: review.id, comment: comment_params }
+      }.to_not change(user.comments, :count)
     end
 
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CommentsController, type: :controller do
+  describe "GET #create" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:review) {FactoryBot.create(:review, user: user)}
+
+    it "コメントを投稿できること" do
+      comment_params = FactoryBot.attributes_for(:comment, review: review)
+      sign_in user
+      expect {
+        post :create, format: ["text/html"], params: { review_id: review.id, comment: comment_params }
+      }.to change(review.comments, :count).by(1)
+    end
+
+    it 'コメントを投稿できないこと' do
+      comment_params = FactoryBot.attributes_for(:comment, :invalid)
+        sign_in user
+        expect {
+          post :create, format: ["text/html"], params: { review_id: review.id, comment: comment_params }
+        }.to_not change(user.comments, :count)
+    end
+
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe CommentsController, type: :controller do
         post :create, format: ["text/html"], params: { review_id: review.id, comment: comment_params }
       }.to_not change(user.comments, :count)
     end
+  end
 
+  describe "DELETE #destroy" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:review) {FactoryBot.create(:review, user: user)}
+    let!(:comment) {FactoryBot.create(:comment, review: review)}
+    
+    context "コメントを投稿したユーザー本人であれば" do
+
+      it "コメントを削除できること" do
+        sign_in user
+        expect {
+          delete :destroy, format: ["text/html"], params: { id: comment.id }
+        }.to change{ Comment.count }.by(-1)
+      end
+    end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CommentsController, type: :controller do
-  describe "GET #create" do
+  describe "POST #create" do
     let(:user) { FactoryBot.create(:user) }
     let(:review) {FactoryBot.create(:review, user: user)}
 


### PR DESCRIPTION
# What
Commentsコントローラーの単体テストの実装

# Why
コントローラーが想定どおりに動作しているかを確認するため。
（しかし、コントローラーの単体テストは現在では推奨されておらず、代わりに統合テストで確認することが推奨されている。そのため、コントローラーの単体テストは中途半端な状態ではあるが、今後はモデルのテストや統合テストに移行する）