### PR TITLE
socketの位置を変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  socket: /tmp/mysql.sock
+  socket: /var/lib/mysql/mysql.sock
 
 development:
   <<: *default


### PR DESCRIPTION
# What
database.ymlで指定しているsocketの位置を変更

# Why
読み込み先のsocketの位置とdatabase.ymlで指定しているsocketの位置が違うために、デプロイできずエラーが発生していると考えたため。