### PR TITLE
ログローテートの設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" >
     
     <%# ↓ Gemのgonを読み込み、Railsで定義した変数をJavaScriptでも使えるようにする %>
-    <%= include_gon %>
+    <%= Gon::Base.render_data %>
   </head>
 
   <body>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,7 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  
+  # production.rbにおいて、「一週間より前のログを切り捨てる」というログローテートを設定
+  config.logger = Logger.new("log/production.log", 'weekly')
 end


### PR DESCRIPTION
# What
ログローテートの設定

# Why
production.logのログが肥大化することを防ぐため。