### PR TITLE
capistranoのバージョンを3.14.1に変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       thor (>= 0.20)
       tty-table (~> 0.10)
     byebug (11.1.3)
-    capistrano (3.15.0)
+    capistrano (3.14.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)


### PR DESCRIPTION
# What
capistranoのバージョンを3.14.1に変更

# Why
AWSにデプロイしようとすると、
「cap aborted! Capfile locked at 3.14.1, but 3.15.0 is loaded」
というエラーメッセージが表示され、デプロイできないため。